### PR TITLE
feat(core-utils):에러핸들러,인증미들웨어,example,zod에러유틸,암호화유틸추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,15 @@
       "version": "1.0.0",
       "dependencies": {
         "@prisma/client": "^6.14.0",
+        "argon2": "^0.44.0",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "express-jwt": "^8.5.1",
         "jsonwebtoken": "^9.0.2",
-        "multer": "^2.0.1"
+        "multer": "^2.0.1",
+        "zod": "^4.1.12"
       },
       "devDependencies": {
         "@types/cookie-parser": "^1.4.9",
@@ -564,6 +566,12 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.11",
@@ -1480,6 +1488,15 @@
         "@noble/hashes": "^1.1.5"
       }
     },
+    "node_modules/@phc/format": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@phc/format/-/format-1.0.0.tgz",
+      "integrity": "sha512-m7X9U6BG2+J+R1lSOdCiITLLrxm+cWlNI3HUFA92oLO77ObGNzaKdh8pMLqdZcshtkKuV84olNNXDfMc4FezBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -2305,6 +2322,22 @@
       "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
       "license": "MIT"
     },
+    "node_modules/argon2": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/argon2/-/argon2-0.44.0.tgz",
+      "integrity": "sha512-zHPGN3S55sihSQo0dBbK0A5qpi2R31z7HZDZnry3ifOyj8bZZnpZND2gpmhnRGO1V/d555RwBqIK5W4Mrmv3ig==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@phc/format": "^1.0.0",
+        "cross-env": "^10.0.0",
+        "node-addon-api": "^8.5.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
     "node_modules/argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -3058,11 +3091,27 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/cross-env": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -4250,7 +4299,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -5471,12 +5519,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-addon-api": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
+      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
     "node_modules/node-fetch-native": {
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
       "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -5803,7 +5871,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6245,7 +6312,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -6258,7 +6324,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7107,7 +7172,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -7352,6 +7416,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
+      "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -19,13 +19,15 @@
   },
   "dependencies": {
     "@prisma/client": "^6.14.0",
+    "argon2": "^0.44.0",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "express-jwt": "^8.5.1",
     "jsonwebtoken": "^9.0.2",
-    "multer": "^2.0.1"
+    "multer": "^2.0.1",
+    "zod": "^4.1.12"
   },
   "devDependencies": {
     "@types/cookie-parser": "^1.4.9",
@@ -38,10 +40,10 @@
     "@types/supertest": "^6.0.3",
     "jest": "^30.1.3",
     "nodemon": "^3.1.10",
+    "prisma": "^6.14.0",
     "supertest": "^7.1.4",
     "ts-jest": "^29.4.3",
     "tsx": "^4.20.3",
-    "typescript": "^5.9.2",
-    "prisma": "^6.14.0"
+    "typescript": "^5.9.2"
   }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,7 @@ import cors from 'cors';
 import cookieParser from 'cookie-parser';
 import express, { Express } from 'express';
 import routes from './routes/index'
+import { errorHandler } from './middlewares/errorHandler';
 dotenv.config();
 
 const app: Express = express()
@@ -22,5 +23,11 @@ app.use(cookieParser());
  * Routes (API)
  */
 app.use('/api', routes);
+
+/**
+ * 글로벌 에러 핸들러
+ */
+app.use(errorHandler);
+
 
 export { app }

--- a/src/errors/ApiError.ts
+++ b/src/errors/ApiError.ts
@@ -1,0 +1,106 @@
+export type ErrorType = 'BAD_REQUEST' | 'NOT_FOUND' | 'UNAUTHORIZED' | 'FORBIDDEN' | 'CONFLICT' | 'INTERNAL';
+
+const ERROR_DEFINITIONS: Record<ErrorType, { code: number; defaultMessage: string }> = {
+  BAD_REQUEST: { code: 400, defaultMessage: '잘못된 요청입니다.' },
+  NOT_FOUND: { code: 404, defaultMessage: '존재하지 않는 리소스입니다.' },
+  UNAUTHORIZED: { code: 401, defaultMessage: '로그인이 필요합니다.' },
+  FORBIDDEN: { code: 403, defaultMessage: '접근 권한이 없습니다.' },
+  CONFLICT: { code: 409, defaultMessage: '이미 존재하는 리소스입니다.' },
+  INTERNAL: { code: 500, defaultMessage: '서버 내부 오류입니다.' },
+};
+
+export interface ApiErrorDetail {
+  path?: string;
+  message: string;
+  context?: string;
+}
+
+export class ApiError extends Error {
+  code: number;
+  status: number;
+  details?: ApiErrorDetail[];
+
+  constructor(
+    code: number,
+    message: string,
+    options?: { status?: number; details?: ApiErrorDetail[] }
+  ) {
+    super(message);
+    this.code = code;
+    this.status = options?.status ?? code; // code와 status는 기본 동일
+    this.details = options?.details;
+    Object.setPrototypeOf(this, ApiError.prototype);
+  }
+
+  /**
+ * @example
+ * import { ApiError } from '#errors/api-error';
+ * 
+ * // ------------------------------------------
+ * // 1. 정적 메서드 사용 - 표준 HTTP 에러
+ * // ------------------------------------------
+ * throw ApiError.badRequest('상품명이 비어 있습니다.');
+ * throw ApiError.notFound(); // 기본 메시지 사용
+ * throw ApiError.unauthorized('로그인이 필요합니다.');
+ * 
+ * // ------------------------------------------
+ * // 2️. of() / type() 사용 - 커스텀 에러 타입
+ * // ------------------------------------------
+ * throw ApiError.of('FORBIDDEN', '해당 리소스를 수정할 권한이 없습니다.');
+ * throw ApiError.of('CONFLICT', '이미 사용 중인 이메일입니다.', {
+ *   details: [
+ *     { path: 'email', message: '중복된 이메일입니다.' },
+ *   ],
+ * });
+ * 
+ * // ------------------------------------------
+ * // 3. try/catch에서 사용 예시
+ * // ------------------------------------------
+ * try {
+ *   const user = await findUser(id);
+ *   if (!user) throw ApiError.notFound();
+ *   
+ *   if (!user.canEdit) {
+ *     throw ApiError.of('FORBIDDEN', '해당 리소스를 수정할 권한이 없습니다.');
+ *   }
+ * } catch (err) {
+ *   next(err); // Express 전역 에러 핸들러로 전달
+ * }
+ * 
+ * //4. new ApiError 직접 생성
+ * // ------------------------------------------
+ * //details 선택사항
+ * throw new ApiError(401, '토큰이 만료되었습니다.', { details: [{ message: '재로그인이 필요합니다.' }] });
+ * 
+ */
+
+
+  static of(type: ErrorType, message?: string, options?: { status?: number; details?: ApiErrorDetail[] }): ApiError {
+    const { code, defaultMessage } = ERROR_DEFINITIONS[type];
+    return new ApiError(code, message || defaultMessage, options);
+  }
+
+  static badRequest(message?: string): ApiError {
+    return ApiError.of('BAD_REQUEST', message);
+  }
+
+  static notFound(message?: string): ApiError {
+    return ApiError.of('NOT_FOUND', message);
+  }
+
+  static unauthorized(message?: string): ApiError {
+    return ApiError.of('UNAUTHORIZED', message);
+  }
+
+  static forbidden(message?: string): ApiError {
+    return ApiError.of('FORBIDDEN', message);
+  }
+
+  static conflict(message?: string): ApiError {
+    return ApiError.of('CONFLICT', message);
+  }
+
+  static internal(message?: string): ApiError {
+    return ApiError.of('INTERNAL', message);
+  }
+}

--- a/src/middlewares/authMiddleware.ts
+++ b/src/middlewares/authMiddleware.ts
@@ -1,0 +1,16 @@
+// import type { RequestHandler } from 'express';
+// import tokenUtils from '#modules/auth/utils/tokenUtils';
+// import { ApiError }  from '../errors/ApiError';
+
+// export const authMiddleware: RequestHandler = (req, res, next) => {
+//   const authHeader = req.headers.authorization;
+//   const token = authHeader?.startsWith('Bearer ') ? authHeader.split(' ')[1] : null;
+
+//   if (!token) throw ApiError.unauthorized('토큰이 존재하지 않습니다.');
+
+//   const decoded = tokenUtils.verifyAccessToken(token);
+
+//   req.user = { id: decoded.id };
+
+//   next();
+// };

--- a/src/middlewares/errorHandler.ts
+++ b/src/middlewares/errorHandler.ts
@@ -1,0 +1,25 @@
+import type { ErrorRequestHandler } from 'express';
+import { ApiError } from '../errors/ApiError';
+
+export const errorHandler: ErrorRequestHandler = (err, _req, res, _next) => {
+  const isApiError = err instanceof ApiError;
+
+  const status = isApiError ? err.status : 500;
+  const code = isApiError ? err.code : 'INTERNAL';
+  const message = err instanceof Error ? err.message : 'Internal server error';
+  const details = isApiError ? err.details : undefined;
+
+  const payload: Record<string, any> = {
+    success: false,
+    error: {
+      code,
+      message,
+    },
+  };
+
+  if (details) {
+    payload.error.details = details;
+  }
+
+  return res.status(status).json(payload);
+};

--- a/src/modules/auth/utils/passwordUtils.ts
+++ b/src/modules/auth/utils/passwordUtils.ts
@@ -1,0 +1,27 @@
+import argon2 from 'argon2';
+
+const PEPPER = process.env.PASSWORD_PEPPER ?? '';
+
+/**
+ * 문자열을 유니코드 정규화(NFKC) 방식으로 변환
+ */
+const normalize = (s: string) => s.normalize('NFKC');
+
+/**
+ * 평문 비밀번호 + pepper를 argon2로 해싱
+ */
+export const hashPassword = async (plain: string): Promise<string> => {
+  return argon2.hash(`${PEPPER}${normalize(plain)}`);
+};
+
+/**
+ * 평문 비밀번호와 해시 비교
+ */
+export const isPasswordValid = async (plain: string, hash: string): Promise<boolean> => {
+  try {
+    return await argon2.verify(hash, `${PEPPER}${normalize(plain)}`);
+  } catch (err) {
+    console.error('Password verify error:', err);
+    return false;
+  }
+};

--- a/src/modules/auth/utils/tokenUtils.ts
+++ b/src/modules/auth/utils/tokenUtils.ts
@@ -1,0 +1,54 @@
+// import jwt from 'jsonwebtoken';
+// import type { DecodedToken } from '#modules/auth/dto/token.dto';
+// import type { AuthHeaderDto } from '#modules/auth/dto/token.dto';
+// import ApiError from '#errors/ApiError';
+
+// const ACCESS_SECRET = process.env.ACCESS_TOKEN_SECRET;
+// const REFRESH_SECRET = process.env.REFRESH_TOKEN_SECRET;
+
+// if (!ACCESS_SECRET || !REFRESH_SECRET) throw new Error('❌ Invalid ACCESS_TOKEN_SECRET or REFRESH_TOKEN_SECRET');
+
+// const extractToken = (authHeader: AuthHeaderDto): string => {
+//   if (!authHeader.authorization.startsWith('Bearer ')) throw ApiError.unauthorized('토큰 형식이 올바르지 않습니다.');
+//   return authHeader.authorization.slice(7);
+// };
+
+// const generateAccessToken = (user: { id: number }): string => {
+//   try {
+//     return jwt.sign({ id: user.id }, ACCESS_SECRET, { expiresIn: '1h' });
+//   } catch (err) {
+//     throw new ApiError(500, '❌ Access Token 생성에 실패했습니다.');
+//   }
+// };
+
+// const verifyAccessToken = (token: string): DecodedToken => {
+//   try {
+//     return jwt.verify(token, ACCESS_SECRET) as DecodedToken;
+//   } catch {
+//     throw new ApiError(403, '❌ Access Token이 유효하지 않습니다.');
+//   }
+// };
+
+// const generateRefreshToken = (user: { id: number }): string => {
+//   try {
+//     return jwt.sign({ id: user.id }, REFRESH_SECRET, { expiresIn: '14d' });
+//   } catch (err) {
+//     throw new ApiError(500, '❌ Refresh Token 생성에 실패했습니다.');
+//   }
+// };
+
+// const verifyRefreshToken = (token: string): DecodedToken => {
+//   try {
+//     return jwt.verify(token, REFRESH_SECRET) as DecodedToken;
+//   } catch {
+//     throw new ApiError(403, '❌ Refresh Token이 유효하지 않습니다.');
+//   }
+// };
+
+// export default {
+//   extractToken,
+//   generateAccessToken,
+//   verifyAccessToken,
+//   generateRefreshToken,
+//   verifyRefreshToken,
+// };

--- a/src/modules/sample/auth.validator.ts
+++ b/src/modules/sample/auth.validator.ts
@@ -1,0 +1,37 @@
+import type { RequestHandler } from 'express';
+import { forwardZodError } from '../../utils/zod';
+import { authCreateSchema } from './dto/register.dto';
+import { loginSchema } from './dto/login.dto';
+
+const validateAuthRegister: RequestHandler = async (req, res, next) => {
+  try {
+    const parsedBody = {
+      email: req.body.email,
+      name: req.body.name,
+      password: req.body.password,
+      profileImage: req.body.profileImage,
+    };
+    await authCreateSchema.parseAsync(parsedBody);
+    next();
+  } catch (err) {
+    forwardZodError(err, '사용자 등록', next);
+  }
+};
+
+const validateAuthLogin: RequestHandler = async (req, res, next) => {
+  try {
+    const parsedBody = {
+      email: req.body.email,
+      password: req.body.password,
+    };
+    await loginSchema.parseAsync(parsedBody);
+    next();
+  } catch (err) {
+    forwardZodError(err, '사용자 로그인', next);
+  }
+};
+
+export default {
+  validateAuthRegister,
+  validateAuthLogin,
+};

--- a/src/modules/sample/dto/login.dto.ts
+++ b/src/modules/sample/dto/login.dto.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const loginSchema = z.object({
+  email: z.email('유효한 이메일 주소가 아닙니다.'),
+  password: z.string().min(8, '비밀번호는 최소 8자 이상이어야 합니다').max(20, '비밀번호는 최대 20자 이하여야 합니다'),
+});
+
+export type LoginDto = z.infer<typeof loginSchema>;

--- a/src/modules/sample/dto/register.dto.ts
+++ b/src/modules/sample/dto/register.dto.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod';
+import dns from 'dns/promises';
+
+const emailWithMX = z.string().refine(
+  async (email) => {
+    const domain = email.split('@')[1];
+    try {
+      const records = await dns.resolveMx(domain);
+      return records && records.length > 0;
+    } catch {
+      return false;
+    }
+  },
+  {
+    message: '유효한 이메일 주소가 아닙니다.',
+  }
+);
+
+export const authCreateSchema = z.object({
+  email: emailWithMX,
+  name: z
+    .string()
+    .min(2, '이름은 최소 2자 이상이어야 합니다')
+    .max(20, '이름은 최대 20자 이하여야 합니다')
+    .regex(/^[a-zA-Z0-9가-힣]+$/, '이름에 특수문자는 사용할 수 없습니다.'),
+  password: z.string().min(8, '비밀번호는 최소 8자 이상이어야 합니다').max(20, '비밀번호는 최대 20자 이하여야 합니다'),
+  profileImage: z.url('이미지 URL 형식이 올바르지 않습니다.').nullable().optional(),
+});
+
+export type RegisterDto = z.infer<typeof authCreateSchema>;
+
+export enum SocialProvider {
+  GOOGLE = 'GOOGLE',
+  NAVER = 'NAVER',
+}
+
+export interface SocialRegisterDto {
+  email: string;
+  name: string;
+  profileImage: string | null;
+  socialAccounts: {
+    provider: SocialProvider;
+    providerUid: string;
+    accessToken: string;
+    refreshToken: string;
+    expiryDate: Date;
+  };
+}

--- a/src/utils/zod.ts
+++ b/src/utils/zod.ts
@@ -1,0 +1,48 @@
+import { ZodError } from 'zod';
+import type { NextFunction } from 'express';
+import { ApiError } from '../errors/ApiError';
+
+/**
+ * 주어진 에러가 ZodError라면 에러 메시지를 포맷팅하여
+ * ApiError(400)으로 감싸 Express 에러 핸들러로 전달합니다.
+ * 
+ * ZodError가 아니라면 원본 에러를 그대로 전달합니다.
+ *
+ * @param err - try/catch 블록에서 잡힌 에러 객체
+ * @param context - 에러 메시지에 포함할 컨텍스트 (예: '상품 등록')
+ * @param next - Express의 next 함수
+ * 
+ * @example
+ * const validateAuthLogin: RequestHandler = async (req, res, next) => {
+  try {
+    const parsedBody = {
+      email: req.body.email,
+      password: req.body.password,
+    };
+    await loginSchema.parseAsync(parsedBody);
+    next();
+  } catch (err) {
+    forwardZodError(err, '사용자 로그인', next);
+  }
+};
+ */
+export const forwardZodError = (err: unknown, context: string, next: NextFunction): void => {
+  if (err instanceof ZodError) {
+    const details = err.issues.map((issue) => ({
+      path: issue.path.join('.'),
+      message: issue.message,
+    }));
+
+    // 문자열 메시지는 요약본으로, 세부는 ApiError의 details 필드에 담기
+    const summary = details.map((detail) => `${detail.path}: ${detail.message}`).join(', ');
+    const message = `${context} 유효성 검사 실패: ${summary}`;
+
+    return next(new ApiError(400, message, { details }));
+  }
+
+  // 예상치 못한 에러일 경우도 Error 객체로 변환 보장
+  const normalizedError =
+    err instanceof Error ? err : new Error(String(err));
+
+  return next(normalizedError);
+};


### PR DESCRIPTION
##  변경사항
1. `package.json`에 암호화 및 유효성 검사용 패키지 `argon2`, `zod` 설치  
2. `errors` 폴더에 `ApiError.ts` 추가 및 **에러 핸들러 미들웨어** 구현  
3. **인증 미들웨어** 추가  
4. **Zod 에러 처리 로직** 추가

##  자세한 내용
1. 새로운 패키지 설치가 필요하므로 `npm install` 또는 `npm i`를 실행해주세요.  
2. `ApiError.ts`에 사용 예제를 작성해두었으며, `app.ts`에 에러 핸들러를 적용했습니다.  
3. 인증 미들웨어를 추가해두었으며, 추후 인증 로직이 완성되면 본격적으로 사용 가능할 예정입니다.  
4. `zod` 사용법 관련 예제를 `dto` 폴더의 `auth.validator.ts`에 추가했습니다.  
   - 참고용으로 `zod.ts`에도 간단한 사용법을 명시해두었습니다.

##  비고
- `npm install`을 반드시 실행해주세요.  
- 에러 핸들러 및 `zod` 구조는 추후 공통 규칙에 따라 확장 가능합니다.  
- 인증 미들웨어는 인증 기능 완료 후 활성화될 예정입니다.
