### PR TITLE
feat(s3): s3 이미지 삭제 유틸 구현

### DIFF
--- a/src/utils/s3DeleteUtils.ts
+++ b/src/utils/s3DeleteUtils.ts
@@ -1,0 +1,92 @@
+import { S3Client, DeleteObjectCommand } from '@aws-sdk/client-s3';
+import {
+  AWS_REGION,
+  AWS_ACCESS_KEY_ID,
+  AWS_SECRET_ACCESS_KEY,
+  AWS_S3_BUCKET_NAME,
+} from '@modules/s3/utils/s3Constants';
+
+/**
+ * S3 클라이언트를 생성합니다.
+ * @returns S3Client 인스턴스
+ */
+const createS3Client = () => {
+  return new S3Client({
+    region: AWS_REGION,
+    credentials: {
+      accessKeyId: AWS_ACCESS_KEY_ID,
+      secretAccessKey: AWS_SECRET_ACCESS_KEY,
+    },
+  });
+};
+
+/**
+ * S3 URL에서 객체 키를 추출합니다.
+ * @param url - S3 이미지의 전체 URL
+ * @returns 추출된 S3 키 (예: "uploads/1234567890-image.jpg")
+ *
+ * @example
+ * const url = "https://bucket-name.s3.ap-northeast-2.amazonaws.com/uploads/1234-image.jpg";
+ * const key = extractS3KeyFromUrl(url);
+ * // key: "uploads/1234-image.jpg"
+ */
+export const extractS3KeyFromUrl = (url: string): string => {
+  try {
+    const urlObj = new URL(url);
+    // pathname은 /uploads/1234-image.jpg 형태이므로 앞의 / 제거
+    const key = urlObj.pathname.startsWith('/')
+      ? urlObj.pathname.slice(1)
+      : urlObj.pathname;
+    return key;
+  } catch (error) {
+    console.error('URL 파싱 오류:', error);
+    // URL 파싱 실패 시 마지막 부분을 키로 사용 (fallback)
+    const parts = url.split('.amazonaws.com/');
+    return parts.length > 1 ? parts[1] : url;
+  }
+};
+
+/**
+ * S3에서 이미지를 삭제합니다.
+ * 이미지가 존재하지 않거나 삭제 중 오류가 발생해도 조용히 무시합니다.
+ *
+ * @param imageUrl - 삭제할 이미지의 전체 S3 URL
+ * @returns Promise<void>
+ *
+ * @example
+ * // Product 수정 시 기존 이미지 삭제
+ * if (existingProduct.image && dto.image && existingProduct.image !== dto.image) {
+ *   await deleteImageFromS3(existingProduct.image);
+ * }
+ *
+ * @example
+ * // Store 삭제 시 이미지 삭제
+ * if (store.image) {
+ *   await deleteImageFromS3(store.image);
+ * }
+ */
+export const deleteImageFromS3 = async (imageUrl: string): Promise<void> => {
+  try {
+    // URL에서 키 추출
+    const key = extractS3KeyFromUrl(imageUrl);
+
+    if (!key) {
+      console.warn('S3 키 추출 실패:', imageUrl);
+      return;
+    }
+
+    // S3에서 삭제
+    const command = new DeleteObjectCommand({
+      Bucket: AWS_S3_BUCKET_NAME,
+      Key: key,
+    });
+
+    const s3Client = createS3Client();
+    await s3Client.send(command);
+
+    console.log('S3 이미지 삭제 성공:', key);
+  } catch (error) {
+    // 에러가 발생해도 조용히 무시 (이미 삭제된 이미지 등)
+    console.warn('S3 이미지 삭제 중 오류 (무시됨):', error);
+  }
+};


### PR DESCRIPTION
# S3 이미지 삭제 유틸리티 구현

-  본 PR은 Claude Code로 작성되었습니다.

## 변경사항

### 새로운 기능

- **S3 이미지 삭제 유틸리티 함수 추가**: `deleteImageFromS3(imageUrl: string)`
- AWS S3에 업로드된 이미지를 URL 기반으로 삭제하는 기능 구현
- URL에서 S3 키를 자동으로 추출하는 헬퍼 함수 제공
- 에러 발생 시 조용히 무시하는 안전한 삭제 처리 (이미 삭제된 이미지 재삭제 시 문제 없음)

### 파일 구조

```
backend/src/utils/
└── s3DeleteUtils.ts           # S3 삭제 유틸리티 함수
```

### 기술 스택

- **AWS SDK v3** (`@aws-sdk/client-s3`): S3 삭제 (DeleteObjectCommand)
- **TypeScript**: 타입 안정성
- URL 파싱을 통한 S3 키 자동 추출

---

## 자세한 내용 / 사용법

### 유틸리티 함수

#### `deleteImageFromS3(imageUrl: string): Promise<void>`

S3에서 이미지를 삭제합니다. 이미지가 존재하지 않거나 삭제 중 오류가 발생해도 조용히 무시합니다.

**파라미터**

- `imageUrl` (string): 삭제할 이미지의 전체 S3 URL

**반환값**

- `Promise<void>`: 비동기 작업 완료

**특징**

- 에러 발생 시 예외를 던지지 않고 콘솔에 경고 메시지만 출력
- 이미 삭제된 이미지를 다시 삭제 시도해도 안전
- S3 연결 오류 등이 발생해도 서비스 중단 없이 계속 진행

#### `extractS3KeyFromUrl(url: string): string`

S3 URL에서 객체 키를 추출합니다.

**파라미터**

- `url` (string): S3 이미지의 전체 URL

**반환값**

- `string`: 추출된 S3 키 (예: `"uploads/1234567890-image.jpg"`)

**예시**

```typescript
const url = 'https://bucket-name.s3.ap-northeast-2.amazonaws.com/uploads/1234-image.jpg';
const key = extractS3KeyFromUrl(url);
// 결과: "uploads/1234-image.jpg"
```

### 구현 상세

#### 1. 삭제 플로우

1. `deleteImageFromS3` 함수 호출 시 전체 S3 URL 전달
2. `extractS3KeyFromUrl`로 URL에서 S3 객체 키 추출
3. **DeleteObjectCommand**로 S3에서 객체 삭제 요청
4. 성공 시 콘솔에 성공 메시지 출력
5. 실패 시 콘솔에 경고 메시지만 출력 (예외 던지지 않음)

#### 2. URL에서 키 추출

```typescript
export const extractS3KeyFromUrl = (url: string): string => {
  try {
    const urlObj = new URL(url);
    // pathname은 /uploads/1234-image.jpg 형태이므로 앞의 / 제거
    const key = urlObj.pathname.startsWith('/') ? urlObj.pathname.slice(1) : urlObj.pathname;
    return key;
  } catch (error) {
    // URL 파싱 실패 시 fallback 로직
    const parts = url.split('.amazonaws.com/');
    return parts.length > 1 ? parts[1] : url;
  }
};
```

- URL 객체를 사용하여 pathname 추출
- URL 파싱 실패 시 문자열 split으로 fallback 처리

#### 3. S3 클라이언트 설정

```typescript
const s3Client = new S3Client({
  region: AWS_REGION,
  credentials: {
    accessKeyId: AWS_ACCESS_KEY_ID,
    secretAccessKey: AWS_SECRET_ACCESS_KEY,
  },
});
```

- 기존 S3 업로드 유틸리티와 동일한 클라이언트 설정 사용
- `s3Constants.ts`에서 환경 변수 import

#### 4. 에러 처리

```typescript
try {
  // S3 삭제 로직
  await s3Client.send(command);
  console.log('S3 이미지 삭제 성공:', key);
} catch (error) {
  // 에러가 발생해도 조용히 무시 (이미 삭제된 이미지 등)
  console.warn('S3 이미지 삭제 중 오류 (무시됨):', error);
}
```

- 모든 에러를 catch하여 조용히 처리
- 서비스 로직에서 삭제 실패로 인한 중단 방지

### 사용 예시

#### 1. Product 수정 시 기존 이미지 삭제

```typescript
import { deleteImageFromS3 } from '@utils/s3DeleteUtils';

// productService.ts
async updateProduct(id: string, dto: UpdateProductDTO) {
  const existingProduct = await prisma.product.findUnique({
    where: { id }
  });

  // 새 이미지로 교체 시 기존 이미지 삭제
  if (existingProduct.image && dto.image && existingProduct.image !== dto.image) {
    await deleteImageFromS3(existingProduct.image);
  }

  return prisma.product.update({
    where: { id },
    data: dto,
  });
}
```

#### 2. Store 삭제 시 이미지 삭제

```typescript
import { deleteImageFromS3 } from '@utils/s3DeleteUtils';

// storeService.ts
async deleteStore(id: string) {
  const store = await prisma.store.findUnique({
    where: { id }
  });

  // Store 삭제 전 이미지 삭제
  if (store?.image) {
    await deleteImageFromS3(store.image);
  }

  return prisma.store.delete({
    where: { id }
  });
}
```

#### 3. Product 삭제 시 여러 이미지 삭제

```typescript
import { deleteImageFromS3 } from '@utils/s3DeleteUtils';

// productService.ts
async deleteProduct(id: string) {
  const product = await prisma.product.findUnique({
    where: { id },
    include: { images: true }, // 가정: Product가 여러 이미지를 가질 경우
  });

  // 메인 이미지 삭제
  if (product?.image) {
    await deleteImageFromS3(product.image);
  }

  // 추가 이미지들 순차적으로 삭제
  if (product?.images && product.images.length > 0) {
    for (const imageRecord of product.images) {
      await deleteImageFromS3(imageRecord.url);
    }
  }

  return prisma.product.delete({
    where: { id }
  });
}
```

#### 4. 조건부 삭제 (이미지가 있을 때만)

```typescript
import { deleteImageFromS3 } from '@utils/s3DeleteUtils';

// 이미지 null 체크 후 안전하게 삭제
const imageUrl = store?.image;
if (imageUrl) {
  await deleteImageFromS3(imageUrl);
}
```

---

## 비고

### 필수 환경 변수

기존 S3 업로드 기능과 동일한 환경 변수를 사용합니다:

```env
AWS_REGION=ap-northeast-2
AWS_ACCESS_KEY_ID=your_access_key
AWS_SECRET_ACCESS_KEY=your_secret_key
AWS_S3_BUCKET_NAME=your_bucket_name
```

### S3 버킷 권한 설정

S3 객체 삭제를 위해 다음 IAM 권한이 필요합니다:

```json
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Action": ["s3:DeleteObject"],
      "Resource": "arn:aws:s3:::your-bucket-name/*"
    }
  ]
}
```

### 안전한 삭제 처리

- **에러 무시**: 삭제 실패 시 예외를 던지지 않아 서비스 로직이 중단되지 않음
- **멱등성**: 같은 이미지를 여러 번 삭제 시도해도 안전
- **존재 여부 미확인**: S3에서 객체 존재 여부를 먼저 확인하지 않고 바로 삭제 요청 (네트워크 요청 최소화)

### 보안 고려사항

- AWS 자격 증명은 환경 변수로만 관리하며 코드에 하드코딩하지 않음
- URL 파싱을 통해 키를 추출하므로 직접 키를 받는 것보다 안전
- 에러 로그에 민감한 정보가 포함되지 않도록 주의

### 성능 고려사항

- 각 삭제마다 새 S3Client 인스턴스를 생성 (기존 업로드 패턴과 일관성 유지)
- 여러 이미지 삭제 시 순차적으로 처리 (필요 시 병렬 처리로 개선 가능)
- 삭제 실패 시에도 다음 작업이 계속 진행됨

### 적용 가능한 모듈

이 유틸리티는 다음 모듈에서 사용할 수 있습니다:

- **Product 모듈**: 상품 수정/삭제 시 기존 이미지 삭제
- **Store 모듈**: 스토어 수정/삭제 시 로고 이미지 삭제
- **User 모듈**: 사용자 프로필 이미지 변경/삭제 시
- 기타 이미지를 사용하는 모든 모듈
