### PR TITLE
feat(metadata): 등급 정보 조회 구현

### DIFF
--- a/src/modules/metadata/dto/gradeDTO.ts
+++ b/src/modules/metadata/dto/gradeDTO.ts
@@ -1,0 +1,9 @@
+/**
+ * Grade 응답 DTO
+ */
+export interface GradeResponseDto {
+  id: string;
+  name: string;
+  rate: number;
+  minAmount: number;
+}

--- a/src/modules/metadata/metadataController.ts
+++ b/src/modules/metadata/metadataController.ts
@@ -1,0 +1,19 @@
+import { Request, Response } from 'express';
+import { metadataService } from './metadataService';
+
+/**
+ * Metadata Controller
+ * 메타데이터 관련 HTTP 요청 처리
+ */
+class MetadataController {
+  /**
+   * 등급 목록 조회
+   * GET /api/metadata/grades
+   */
+  getGradeList = async (req: Request, res: Response) => {
+    const grades = await metadataService.getGradeList();
+    res.status(200).json(grades);
+  };
+}
+
+export const metadataController = new MetadataController();

--- a/src/modules/metadata/metadataRepo.ts
+++ b/src/modules/metadata/metadataRepo.ts
@@ -1,0 +1,21 @@
+import { prisma } from '@shared/prisma';
+
+/**
+ * Metadata Repository
+ * 메타데이터 관련 데이터베이스 접근 레이어
+ */
+class MetadataRepository {
+  /**
+   * 모든 등급 정보 조회
+   * @returns Grade 목록 (minAmount 오름차순)
+   */
+  getGradeList = async () => {
+    return await prisma.grade.findMany({
+      orderBy: {
+        minAmount: 'asc',
+      },
+    });
+  };
+}
+
+export const metadataRepository = new MetadataRepository();

--- a/src/modules/metadata/metadataRoute.ts
+++ b/src/modules/metadata/metadataRoute.ts
@@ -1,0 +1,12 @@
+import express from 'express';
+import { metadataController } from './metadataController';
+
+const metadataRouter = express.Router();
+
+/**
+ * GET /api/metadata/grades
+ * 등급 목록 조회
+ */
+metadataRouter.get('/grades', metadataController.getGradeList);
+
+export default metadataRouter;

--- a/src/modules/metadata/metadataService.ts
+++ b/src/modules/metadata/metadataService.ts
@@ -1,0 +1,25 @@
+import { metadataRepository } from './metadataRepo';
+import { GradeResponseDto } from './dto/gradeDTO';
+
+/**
+ * Metadata Service
+ * 메타데이터 관련 비즈니스 로직
+ */
+class MetadataService {
+  /**
+   * 등급 목록 조회
+   * @returns 등급 목록 (GradeResponseDto[])
+   */
+  getGradeList = async (): Promise<GradeResponseDto[]> => {
+    const grades = await metadataRepository.getGradeList();
+
+    return grades.map((grade) => ({
+      id: `grade_${grade.name.toLowerCase()}`,
+      name: grade.name,
+      rate: grade.rate,
+      minAmount: grade.minAmount,
+    }));
+  };
+}
+
+export const metadataService = new MetadataService();

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -10,6 +10,7 @@ import reviewRouter from '@modules/review/reviewRoute';
 import inquiryRouter from '@modules/inquiry/inquiryRoute';
 import notificationRouter from '@modules/notification/notificationRoute';
 import dashboardRouter from '@modules/dashboard/dashboardRoute';
+import metadataRouter from '@modules/metadata/metadataRoute';
 
 /*
 	modules에서 route임포트
@@ -32,5 +33,6 @@ router.use('/reviews', reviewRouter);
 router.use('/inquiries', inquiryRouter);
 router.use('/notifications', notificationRouter);
 router.use('/dashboard', dashboardRouter);
+router.use('/metadata', metadataRouter);
 
 export default router;


### PR DESCRIPTION
# 등급 목록 조회 API 구현

- 본 PR 설명은 Cursor로 작성되었습니다.

## 📋 개요
사용자 등급 정보를 조회할 수 있는 메타데이터 API를 구현했습니다.

## ✨ 주요 변경사항

### API 엔드포인트
- **GET** `/api/metadata/grades`
- 등급 목록을 조회하는 엔드포인트 추가

### 구현 내용

#### 1. Repository Layer (`metadataRepo.ts`)
- `getGradeList()` 메서드 구현
- 데이터베이스에서 등급 정보 조회
- `minAmount` 기준 오름차순 정렬

#### 2. Service Layer (`metadataService.ts`)
- `getGradeList()` 메서드 구현
- Repository에서 조회한 데이터를 `GradeResponseDto` 형식으로 변환
- 등급 ID를 `grade_{등급명}` 형식으로 생성

#### 3. Controller Layer (`metadataController.ts`)
- `getGradeList()` 메서드 구현
- HTTP 요청 처리 및 JSON 응답 반환

#### 4. Route 설정 (`metadataRoute.ts`)
- `/grades` 경로에 `getGradeList` 핸들러 연결

### 응답 형식
```typescript
interface GradeResponseDto {
  id: string;        // "grade_{등급명}"
  name: string;      // 등급명
  rate: number;      // 할인율
  minAmount: number; // 최소 구매 금액
}
```

## 🔄 변경된 메서드명
- `getGrades` → `getGradeList`로 통일하여 네이밍 일관성 개선

## 📁 수정된 파일
- `src/modules/metadata/metadataController.ts`
- `src/modules/metadata/metadataService.ts`
- `src/modules/metadata/metadataRepo.ts`
- `src/modules/metadata/metadataRoute.ts`

## 🧪 테스트 방법
```bash
# 등급 목록 조회
GET /api/metadata/grades

# 응답 예시
[
  {
    "id": "grade_bronze",
    "name": "Bronze",
    "rate": 0.05,
    "minAmount": 0
  },
  {
    "id": "grade_silver",
    "name": "Silver",
    "rate": 0.10,
    "minAmount": 100000
  }
]
```

## 결과 이미지

<img width="839" height="641" alt="image" src="https://github.com/user-attachments/assets/3168179e-36ea-4a2c-afc1-2d69684104af" />
